### PR TITLE
Add trailing slash to the dest dir of make install action

### DIFF
--- a/Makefile.python
+++ b/Makefile.python
@@ -1,4 +1,4 @@
-#SERIAL 201601291542
+#SERIAL 201603202246
 
 # Base the name of the software on the spec file
 PACKAGE := $(shell basename *.spec .spec)
@@ -55,7 +55,7 @@ build: clean manpage
 	${PYTHON} setup.py build -f
 
 install: build
-	${PYTHON} setup.py install -f --root ${DESTDIR}
+	${PYTHON} setup.py install -f --root ${DESTDIR}/
 
 install_rpms: rpms
 	yum install ${RPMDIR}/${ARCH}/${PACKAGE}*.${ARCH}.rpm


### PR DESCRIPTION
When running "make install" using "Makefile.python", I get the following error:

```
.../bin/python setup.py install -f --root 
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: option --root requires argument
Makefile:58: recipe for target 'install' failed
make: *** [install] Error 1
```

This is because $DESTDIR defaults to an empty string ([it should](https://www.gnu.org/prep/standards/html_node/DESTDIR.html)) which results in running this malformed command:

```
python setup.py install -f --root
```

With the addition of the trailing slash, we get:

```
python setup.py install -f --root /
```

With this change, "make install" would drop files where they should reside for actual use ([source](https://www.gnu.org/prep/standards/html_node/Standard-Targets.html#Standard-Targets)).
